### PR TITLE
Change the package to AwesomeAssertions 7.1

### DIFF
--- a/MTK.Blazor.Tests/MTK.Blazor.Tests.csproj
+++ b/MTK.Blazor.Tests/MTK.Blazor.Tests.csproj
@@ -11,8 +11,8 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="AwesomeAssertions" Version="7.1.0" />
         <PackageReference Include="bunit" Version="1.25.3" />
-        <PackageReference Include="FluentAssertions" Version="6.12.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0"/>
         <PackageReference Include="NSubstitute" Version="5.1.0" />
         <PackageReference Include="xunit" Version="2.4.2"/>


### PR DESCRIPTION
Remove FluentAssertions version to avoid accidently upgrading to an abusive license, and migrate to AwesomeAssertions.